### PR TITLE
OpenAPI implementation for InstantAPIs

### DIFF
--- a/Fritz.InstantAPIs/Fritz.InstantAPIs.csproj
+++ b/Fritz.InstantAPIs/Fritz.InstantAPIs.csproj
@@ -20,8 +20,8 @@
 
 
 	<Target Name="PreparePackageReleaseNotesFromFile" BeforeTargets="GenerateNuspec">
-		<ReadLinesFromFile File="../RELEASE_NOTES.txt" >
-			<Output TaskParameter="Lines" ItemName="ReleaseNoteLines"/>
+		<ReadLinesFromFile File="../RELEASE_NOTES.txt">
+			<Output TaskParameter="Lines" ItemName="ReleaseNoteLines" />
 		</ReadLinesFromFile>
 		<PropertyGroup>
 			<PackageReleaseNotes>@(ReleaseNoteLines, '%0a')</PackageReleaseNotes>
@@ -40,6 +40,7 @@
 		</None>
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.2" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Fritz.InstantAPIs/InstantAPIsServiceCollectionExtensions.cs
+++ b/Fritz.InstantAPIs/InstantAPIsServiceCollectionExtensions.cs
@@ -1,0 +1,32 @@
+﻿namespace Microsoft.Extensions.DependencyInjection;
+
+public static class InstantAPIsServiceCollectionExtensions
+{
+    public static IServiceCollection AddInstantAPIs(this IServiceCollection services, Action<InstantAPIsServiceOptions>? setupAction = null)
+    {
+        var options = new InstantAPIsServiceOptions();
+
+        // Get the service options
+        setupAction?.Invoke(options);
+
+        if (options.EnableSwagger == null)
+        {
+            options.EnableSwagger = EnableSwagger.DevelopmentOnly;
+        }
+
+        // Add and configure Swagger services if it is enabled
+        if (options.EnableSwagger != EnableSwagger.None)
+        {
+            services.AddEndpointsApiExplorer();
+            services.AddSwaggerGen(options.Swagger);
+        }
+
+        // Register the required options so that it can be accessed by InstantAPIs middleware
+        services.Configure<InstantAPIsServiceOptions>(config =>
+        {
+            config.EnableSwagger = options.EnableSwagger;
+        });
+
+        return services;
+    }
+}

--- a/Fritz.InstantAPIs/InstantAPIsServiceOptions.cs
+++ b/Fritz.InstantAPIs/InstantAPIsServiceOptions.cs
@@ -1,0 +1,17 @@
+﻿using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Fritz.InstantAPIs;
+
+public enum EnableSwagger
+{
+    None,
+    DevelopmentOnly,
+    Always
+}
+
+public class InstantAPIsServiceOptions
+{
+
+    public EnableSwagger? EnableSwagger { get; set; }
+    public Action<SwaggerGenOptions>? Swagger { get; set; }
+}

--- a/Fritz.InstantAPIs/WebApplicationExtensions.cs
+++ b/Fritz.InstantAPIs/WebApplicationExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using System.Reflection;
 
 namespace Microsoft.AspNetCore.Builder;
@@ -7,70 +9,84 @@ namespace Microsoft.AspNetCore.Builder;
 public static class WebApplicationExtensions
 {
 
-	private static InstantAPIsConfig Configuration { get; set; } = new();
+    private static InstantAPIsConfig Configuration { get; set; } = new();
 
-	public static IEndpointRouteBuilder MapInstantAPIs<D>(this IEndpointRouteBuilder app, Action<InstantAPIsConfigBuilder<D>> options = null) where D: DbContext
-	{
+    public static IEndpointRouteBuilder MapInstantAPIs<D>(this IEndpointRouteBuilder app, Action<InstantAPIsConfigBuilder<D>> options = null) where D : DbContext
+    {
+        if (app is IApplicationBuilder applicationBuilder)
+        {
+            // Check if AddInstantAPIs was called by getting the service options and evaluate EnableSwagger property
+            var serviceOptions = applicationBuilder.ApplicationServices.GetRequiredService<IOptions<InstantAPIsServiceOptions>>().Value;
+            if (serviceOptions == null || serviceOptions.EnableSwagger == null)
+            {
+                throw new ArgumentException("Call builder.Services.AddInstantAPIs(options) before MapInstantAPIs.");
+            }
 
-		if (app is IApplicationBuilder applicationBuilder)
-		{
-			var ctx = applicationBuilder.ApplicationServices.CreateScope().ServiceProvider.GetService(typeof(D)) as D;
-			var builder = new InstantAPIsConfigBuilder<D>(ctx);
-			if (options != null)
-			{
-				options(builder);
-				Configuration = builder.Build();
-			}
-		}
+            var webApp = (WebApplication)app;
+            if (serviceOptions.EnableSwagger == EnableSwagger.Always ||
+               (serviceOptions.EnableSwagger == EnableSwagger.DevelopmentOnly && webApp.Environment.IsDevelopment()))
+            {
+                applicationBuilder.UseSwagger();
+                applicationBuilder.UseSwaggerUI();
+            }
 
-		// Get the tables on the DbContext
-		var dbTables = GetDbTablesForContext<D>();
+            var ctx = applicationBuilder.ApplicationServices.CreateScope().ServiceProvider.GetService(typeof(D)) as D;
+            var builder = new InstantAPIsConfigBuilder<D>(ctx);
+            if (options != null)
+            {
+                options(builder);
+                Configuration = builder.Build();
+            }
+        }
 
-		var requestedTables = !Configuration.Tables.Any() ?
-			dbTables :
-			Configuration.Tables.Where(t => dbTables.Any(db => db.Name.Equals(t.Name, StringComparison.OrdinalIgnoreCase))).ToArray();
+        // Get the tables on the DbContext
+        var dbTables = GetDbTablesForContext<D>();
 
-		var allMethods = typeof(MapApiExtensions).GetMethods(BindingFlags.NonPublic | BindingFlags.Static).Where(m => m.Name.StartsWith("Map")).ToArray();
-		var initialize = typeof(MapApiExtensions).GetMethod("Initialize", BindingFlags.NonPublic | BindingFlags.Static);
-		foreach (var table in requestedTables)
-		{
+        var requestedTables = !Configuration.Tables.Any() ?
+            dbTables :
+            Configuration.Tables.Where(t => dbTables.Any(db => db.Name.Equals(t.Name, StringComparison.OrdinalIgnoreCase))).ToArray();
 
-			// The default URL for an InstantAPI is /api/TABLENAME
-			var url = $"/api/{table.Name}";
+        var allMethods = typeof(MapApiExtensions).GetMethods(BindingFlags.NonPublic | BindingFlags.Static).Where(m => m.Name.StartsWith("Map")).ToArray();
+        var initialize = typeof(MapApiExtensions).GetMethod("Initialize", BindingFlags.NonPublic | BindingFlags.Static);
+        foreach (var table in requestedTables)
+        {
 
-			initialize.MakeGenericMethod(typeof(D), table.InstanceType).Invoke(null, null);
+            // The default URL for an InstantAPI is /api/TABLENAME
+            var url = $"/api/{table.Name}";
 
-			// The remaining private static methods in this class build out the Mapped API methods..
-			// let's use some reflection to get them
-			foreach (var method in allMethods)
-			{
+            initialize.MakeGenericMethod(typeof(D), table.InstanceType).Invoke(null, null);
 
-				var sigAttr = method.CustomAttributes.First(x => x.AttributeType == typeof(ApiMethodAttribute)).ConstructorArguments.First();
-				var methodType = (ApiMethodsToGenerate)sigAttr.Value;
-				if ((table.ApiMethodsToGenerate & methodType) != methodType) continue;
+            // The remaining private static methods in this class build out the Mapped API methods..
+            // let's use some reflection to get them
+            foreach (var method in allMethods)
+            {
 
-				var genericMethod = method.MakeGenericMethod(typeof(D), table.InstanceType);
-				genericMethod.Invoke(null, new object[] { app, url });
-			}
+                var sigAttr = method.CustomAttributes.First(x => x.AttributeType == typeof(ApiMethodAttribute)).ConstructorArguments.First();
+                var methodType = (ApiMethodsToGenerate)sigAttr.Value;
+                if ((table.ApiMethodsToGenerate & methodType) != methodType) continue;
 
-		}
+                var genericMethod = method.MakeGenericMethod(typeof(D), table.InstanceType);
+                genericMethod.Invoke(null, new object[] { app, url });
+            }
 
-		return app;
-	}
+        }
 
-	internal static IEnumerable<TypeTable> GetDbTablesForContext<D>() where D : DbContext
-	{
-		return typeof(D).GetProperties(BindingFlags.Instance | BindingFlags.Public)
-					.Where(x => x.PropertyType.FullName.StartsWith("Microsoft.EntityFrameworkCore.DbSet"))
-					.Select(x => new TypeTable { Name = x.Name, InstanceType = x.PropertyType.GenericTypeArguments.First() })
-					.ToArray();
-	}
+        return app;
+    }
 
-	internal class TypeTable
-	{
-		public string Name { get; set; }
-		public Type InstanceType { get; set; }
-		public ApiMethodsToGenerate ApiMethodsToGenerate { get; set; } = ApiMethodsToGenerate.All;
-	}
+    internal static IEnumerable<TypeTable> GetDbTablesForContext<D>() where D : DbContext
+    {
+        return typeof(D).GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                    .Where(x => x.PropertyType.FullName.StartsWith("Microsoft.EntityFrameworkCore.DbSet"))
+                    .Select(x => new TypeTable { Name = x.Name, InstanceType = x.PropertyType.GenericTypeArguments.First() })
+                    .ToArray();
+    }
+
+    internal class TypeTable
+    {
+        public string Name { get; set; }
+        public Type InstanceType { get; set; }
+        public ApiMethodsToGenerate ApiMethodsToGenerate { get; set; } = ApiMethodsToGenerate.All;
+    }
 
 }

--- a/WorkingApi/Program.cs
+++ b/WorkingApi/Program.cs
@@ -1,13 +1,26 @@
 using Fritz.InstantAPIs;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.OpenApi.Models;
 using System.Diagnostics;
 using WorkingApi;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddSqlite<MyContext>("Data Source=contacts.db");
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+//builder.Services.AddEndpointsApiExplorer();
+//builder.Services.AddSwaggerGen();
+builder.Services.AddInstantAPIs(options =>
+{
+    options.EnableSwagger = Fritz.InstantAPIs.EnableSwagger.DevelopmentOnly;
+    options.Swagger = config =>
+    {
+        config.SwaggerDoc("v1", new OpenApiInfo
+        {
+            Title = "My Working API",
+            Description = "An ASP.NET Core Web API"
+        });
+    };
+});
 
 var app = builder.Build();
 
@@ -19,7 +32,7 @@ app.MapInstantAPIs<MyContext>(options =>
 });
 Console.WriteLine($"Elapsed time to build InstantAPIs: {sw.Elapsed}");
 
-app.UseSwagger();
-app.UseSwaggerUI();
+//app.UseSwagger();
+//app.UseSwaggerUI();
 
 app.Run();


### PR DESCRIPTION
Fixes #24 

Added AddInstantAPIs service with options to enable or disable swagger, and throw an exception if MapInstantAPIs is called without calling AddInstantAPIs first.

**Note**: When I ran your project (without modifications), I noticed that Swagger shows GET endpoint only!
