### PR TITLE
Support for Keyless attributes

### DIFF
--- a/InstantAPIs/WebApplicationExtensions.cs
+++ b/InstantAPIs/WebApplicationExtensions.cs
@@ -100,7 +100,8 @@ public static class WebApplicationExtensions
 	internal static IEnumerable<TypeTable> GetDbTablesForContext<D>() where D : DbContext
 	{
 		return typeof(D).GetProperties(BindingFlags.Instance | BindingFlags.Public)
-								.Where(x => x.PropertyType.FullName.StartsWith("Microsoft.EntityFrameworkCore.DbSet"))
+								.Where(x => x.PropertyType.FullName.StartsWith("Microsoft.EntityFrameworkCore.DbSet")
+								&& x.PropertyType.GenericTypeArguments.First().GetCustomAttributes(typeof(KeylessAttribute), true).Length <= 0)
 								.Select(x => new TypeTable { 
 									Name = x.Name, 
 									InstanceType = x.PropertyType.GenericTypeArguments.First(),


### PR DESCRIPTION
If we are scaffolding entities classes will be generated with the `Keyless` attribute. It will generate an exception while calling the `MapInstantAPIs` method. In this fix, if the class is with a `Keyless` attribute, it is ignored.

Fixes #69 