### PR TITLE
Allowed user to override conventions for primary key

### DIFF
--- a/InstantAPIs/InstantAPIs.csproj
+++ b/InstantAPIs/InstantAPIs.csproj
@@ -15,7 +15,7 @@
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<DebugType>embedded</DebugType>
-		<Version>0.2.1</Version>
+		<Version>0.2.2</Version>
 	</PropertyGroup>
 
 

--- a/InstantAPIs/InstantAPIsConfig.cs
+++ b/InstantAPIs/InstantAPIsConfig.cs
@@ -5,6 +5,10 @@ internal class InstantAPIsConfig
 
 	internal HashSet<WebApplicationExtensions.TypeTable> Tables { get; } = new HashSet<WebApplicationExtensions.TypeTable>();
 
+	internal List<string> PrimaryKeyMappingConventions { get; } = new List<string>() {
+		"{ClassName}Id", "{ClassName}_Id", "Id", "ID"
+	};
+
 }
 
 
@@ -17,7 +21,7 @@ public class InstantAPIsConfigBuilder<D> where D : DbContext
 	private readonly HashSet<TableApiMapping> _IncludedTables = new();
 	private readonly List<string> _ExcludedTables = new();
 	private const string DEFAULT_URI = "/api/";
-
+	
 	public InstantAPIsConfigBuilder(D theContext)
 	{
 		this._TheContext = theContext;
@@ -125,6 +129,22 @@ public class InstantAPIsConfigBuilder<D> where D : DbContext
 	}
 
 #endregion
+
+	#region Primary Key Mapping Conventions
+
+	/// <summary>
+	/// Override the convention for determining primary keys of the entities. [Key] data annotation takes priority
+	/// </summary>
+	/// <param name="conventions">A list of conventions. You can use the string {ClassName} for the entity name. Ie: {ClassName}Id</param>
+	/// <returns>Configuration builder with this configuraiton applied</returns>
+	public InstantAPIsConfigBuilder<D> PrimaryKeyMappingConvention(List<string> conventions)
+	{
+		this._Config.PrimaryKeyMappingConventions.Clear();
+		this._Config.PrimaryKeyMappingConventions.AddRange(conventions);
+		return this;
+	}
+	
+	#endregion
 
 	internal InstantAPIsConfig Build()
 	{

--- a/InstantAPIs/InstantAPIsConfig.cs
+++ b/InstantAPIs/InstantAPIsConfig.cs
@@ -6,7 +6,7 @@ internal class InstantAPIsConfig
 	internal HashSet<WebApplicationExtensions.TypeTable> Tables { get; } = new HashSet<WebApplicationExtensions.TypeTable>();
 
 	internal List<string> PrimaryKeyMappingConventions { get; } = new List<string>() {
-		"{ClassName}Id", "{ClassName}_Id", "Id", "ID"
+		"{ClassName}Id", "{ClassName}_Id", "Id"
 	};
 
 }

--- a/InstantAPIs/MapApiExtensions.cs
+++ b/InstantAPIs/MapApiExtensions.cs
@@ -24,9 +24,24 @@ internal class MapApiExtensions
 		Logger = logger;
 
     var theType = typeof(C);
-		var idProp = theType.GetProperty("id", BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance) ?? theType.GetProperties().FirstOrDefault(p => p.CustomAttributes.Any(a => a.AttributeType == typeof(KeyAttribute)));
+    var keyName = $"{theType.Name}Id";
 
-		if (idProp != null)
+    // annotations will always override conventions....
+    var idProp = theType.GetProperties().FirstOrDefault(p => p.CustomAttributes.Any(a => a.AttributeType == typeof(KeyAttribute)));
+    if (idProp == null)
+    {
+	    foreach (var idName in WebApplicationExtensions.Configuration.PrimaryKeyMappingConventions)
+	    {
+		    if (idProp == null)
+		    {
+			    var propertyName = idName.Replace("{ClassName}", theType.Name);
+			    idProp = theType.GetProperty(propertyName,
+				    BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+		    }
+	    }
+    }
+
+    if (idProp != null)
 		{
 			_IdLookup.Add(theType, idProp);
 		}

--- a/InstantAPIs/WebApplicationExtensions.cs
+++ b/InstantAPIs/WebApplicationExtensions.cs
@@ -14,7 +14,7 @@ public static class WebApplicationExtensions
 	
 	internal const string LOGGER_CATEGORY_NAME = "InstantAPI";
 
-	private static InstantAPIsConfig Configuration { get; set; } = new();
+	internal static InstantAPIsConfig Configuration { get; set; } = new();
 
 	public static IEndpointRouteBuilder MapInstantAPIs<D>(this IEndpointRouteBuilder app, Action<InstantAPIsConfigBuilder<D>> options = null) where D : DbContext
 	{

--- a/WorkingApi/Program.cs
+++ b/WorkingApi/Program.cs
@@ -16,6 +16,7 @@ var sw = Stopwatch.StartNew();
 app.MapInstantAPIs<MyContext>(config =>
 {
 	config.IncludeTable(db => db.Contacts, ApiMethodsToGenerate.All, "addressBook");
+	config.PrimaryKeyMappingConvention(new List<string>() { "{ClassName}Id", "{ClassName}_Id", });
 });
 
 app.Run();


### PR DESCRIPTION
Previously the code was check for property called id and assume thats the primary key, or find the data annotation [Key].

If the user does not have any of those the application failed. This now allows a convention to be created out-of-the-box and the user to override that convention if necessary.

It also changes the order so if there is a [Key] annotation, that is used by default.