### PR TITLE
Using a fixture to setup instant api config builder tests

### DIFF
--- a/Test/Configuration/InstantAPIsConfigBuilderFixture.cs
+++ b/Test/Configuration/InstantAPIsConfigBuilderFixture.cs
@@ -1,0 +1,19 @@
+﻿using InstantAPIs;
+using Microsoft.EntityFrameworkCore;
+
+namespace Test.Configuration;
+
+public abstract class InstantAPIsConfigBuilderFixture : BaseFixture
+{
+	internal InstantAPIsConfigBuilder<MyContext> _Builder;
+
+	public InstantAPIsConfigBuilderFixture()
+	{
+
+		var _ContextOptions = new DbContextOptionsBuilder<MyContext>()
+			.UseInMemoryDatabase("TestDb")
+			.Options;
+		_Builder = new(new(_ContextOptions));
+
+	}
+}

--- a/Test/Configuration/WhenIncludeDoesNotSpecifyBaseUrl.cs
+++ b/Test/Configuration/WhenIncludeDoesNotSpecifyBaseUrl.cs
@@ -1,24 +1,9 @@
-﻿using InstantAPIs;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.EntityFrameworkCore;
-using Xunit;
+﻿using Xunit;
 
 namespace Test.Configuration;
 
-public class WhenIncludeDoesNotSpecifyBaseUrl : BaseFixture
+public class WhenIncludeDoesNotSpecifyBaseUrl : InstantAPIsConfigBuilderFixture
 {
-
-	InstantAPIsConfigBuilder<MyContext> _Builder;
-
-	public WhenIncludeDoesNotSpecifyBaseUrl()
-	{
-
-		var _ContextOptions = new DbContextOptionsBuilder<MyContext>()
-		.UseInMemoryDatabase("TestDb")
-		.Options;
-		_Builder = new(new(_ContextOptions));
-
-	}
 
 	[Fact]
 	public void ShouldSpecifyDefaultUrl()
@@ -35,8 +20,4 @@ public class WhenIncludeDoesNotSpecifyBaseUrl : BaseFixture
 		Assert.Equal(new Uri("/api/Contacts", uriKind: UriKind.Relative), config.Tables.First().BaseUrl);
 
 	}
-
-
 }
-
-

--- a/Test/Configuration/WhenIncludeSpecifiesBaseUrl.cs
+++ b/Test/Configuration/WhenIncludeSpecifiesBaseUrl.cs
@@ -1,30 +1,9 @@
-﻿using InstantAPIs;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Xunit;
+﻿using Xunit;
 
 namespace Test.Configuration;
 
-
-public class WhenIncludeSpecifiesBaseUrl : BaseFixture
+public class WhenIncludeSpecifiesBaseUrl : InstantAPIsConfigBuilderFixture
 {
-
-	InstantAPIsConfigBuilder<MyContext> _Builder;
-
-	public WhenIncludeSpecifiesBaseUrl()
-	{
-
-		var _ContextOptions = new DbContextOptionsBuilder<MyContext>()
-		.UseInMemoryDatabase("TestDb")
-		.Options;
-		_Builder = new(new(_ContextOptions));
-
-	}
 
 	[Fact]
 	public void ShouldSpecifyThatUrl()
@@ -42,8 +21,4 @@ public class WhenIncludeSpecifiesBaseUrl : BaseFixture
 		Assert.Equal(BaseUrl, config.Tables.First().BaseUrl);
 
 	}
-
-
 }
-
-

--- a/Test/Configuration/WithIncludesAndExcludes.cs
+++ b/Test/Configuration/WithIncludesAndExcludes.cs
@@ -1,24 +1,10 @@
-﻿using InstantAPIs;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.EntityFrameworkCore;
-using Xunit;
+﻿using Xunit;
 
 namespace Test.Configuration;
 
-public class WithIncludesAndExcludes : BaseFixture
+public class WithIncludesAndExcludes : InstantAPIsConfigBuilderFixture
 {
 
-	InstantAPIsConfigBuilder<MyContext> _Builder;
-
-	public WithIncludesAndExcludes()
-	{
-
-		var _ContextOptions = new DbContextOptionsBuilder<MyContext>()
-		.UseInMemoryDatabase("TestDb")
-		.Options;
-		_Builder = new(new(_ContextOptions));
-
-	}
 
 	[Fact]
 	public void ShouldExcludePreviouslyIncludedTable()
@@ -39,4 +25,3 @@ public class WithIncludesAndExcludes : BaseFixture
 	}
 
 }
-

--- a/Test/Configuration/WithOnlyExcludes.cs
+++ b/Test/Configuration/WithOnlyExcludes.cs
@@ -1,25 +1,9 @@
-﻿using InstantAPIs;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.EntityFrameworkCore;
-using System.Linq;
-using Xunit;
+﻿using Xunit;
 
 namespace Test.Configuration;
 
-public class WithOnlyExcludes : BaseFixture
+public class WithOnlyExcludes : InstantAPIsConfigBuilderFixture
 {
-
-	InstantAPIsConfigBuilder<MyContext> _Builder;
-
-	public WithOnlyExcludes()
-	{
-
-		var _ContextOptions = new DbContextOptionsBuilder<MyContext>()
-		.UseInMemoryDatabase("TestDb")
-		.Options;
-		_Builder = new(new(_ContextOptions));
-
-	}
 
 	[Fact]
 	public void ShouldExcludeSpecifiedTable()
@@ -52,4 +36,3 @@ public class WithOnlyExcludes : BaseFixture
 	}
 
 }
-

--- a/Test/Configuration/WithOnlyIncludes.cs
+++ b/Test/Configuration/WithOnlyIncludes.cs
@@ -1,29 +1,10 @@
 ﻿using InstantAPIs;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Test.Configuration;
 
-public class WithOnlyIncludes : BaseFixture
+public class WithOnlyIncludes : InstantAPIsConfigBuilderFixture
 {
-
-	InstantAPIsConfigBuilder<MyContext> _Builder;
-
-	public WithOnlyIncludes()
-	{
-
-		var _ContextOptions = new DbContextOptionsBuilder<MyContext>()
-		.UseInMemoryDatabase("TestDb")
-		.Options;
-		_Builder = new(new(_ContextOptions));
-
-	}
 
 	[Fact]
 	public void ShouldNotIncludeAllTables()

--- a/Test/Configuration/WithoutIncludes.cs
+++ b/Test/Configuration/WithoutIncludes.cs
@@ -39,4 +39,3 @@ public class WithoutIncludes : BaseFixture
 	}
 
 }
-


### PR DESCRIPTION
This is a house cleaning PR that will not impact any current application behaviour. But taking the DRY principle in mind, I want to reduce some duplicated code in the application.

Therefore I'm using a central test fixture to set up the tests around the configuration builder, so we do not duplicate the creation of the setup mock.